### PR TITLE
Fix calculation of previous SVN revision needed by -c option

### DIFF
--- a/src/diffuse/vcs/svn.py
+++ b/src/diffuse/vcs/svn.py
@@ -58,7 +58,7 @@ class Svn(VcsInterface):
         if rev is None:
             return 'BASE'
         m = int(rev)
-        return str(max(m > 1, 0))
+        return str(max(m - 1, 0))
 
     def _getURL(self, prefs: Preferences) -> Optional[str]:
         if self.url is None:


### PR DESCRIPTION
Using -c option with SVN repo was broken because this method would return True instead of the previous revision number.